### PR TITLE
ENV-based AWS auth

### DIFF
--- a/endpoints/middleware/image-upload.js
+++ b/endpoints/middleware/image-upload.js
@@ -10,9 +10,22 @@ const bucketName = process.env.S3_BUCKET_NAME;
 // });
 // aws.config.credentials = credentials;
 
+aws.config.credentials = {
+  expired: false,
+  expireTime: null,
+  refreshCallbacks: [],
+  accessKeyId: process.env.S3_IAM_USER_KEY,
+  sessionToken: undefined,
+  filename: undefined,
+  disableAssumeRole: false,
+  preferStaticCredentials: false,
+  tokenCodeFn: null,
+  httpOptions: null
+};
+
 const s3 = new aws.S3({
-  accesKeyId: process.env.S3_IAM_USER_KEY,
-  secretAccessKey: process.env.S3_IAM_USER_SECRET
+  accessKeyId: process.env.S3_IAM_USER_KEY,
+  secretAccessKey: process.env.s3_IAM_USER_SECRET
 });
 
 const fileFilter = (request, file, cb) => {

--- a/endpoints/middleware/image-upload.js
+++ b/endpoints/middleware/image-upload.js
@@ -5,11 +5,6 @@ const multers3 = require("multer-s3");
 
 const bucketName = process.env.S3_BUCKET_NAME;
 
-// var credentials = new aws.SharedIniFileCredentials({
-//   profile: "mydishaws"
-// });
-// aws.config.credentials = credentials;
-
 aws.config.credentials = {
   expired: false,
   expireTime: null,
@@ -25,7 +20,7 @@ aws.config.credentials = {
 
 const s3 = new aws.S3({
   accessKeyId: process.env.S3_IAM_USER_KEY,
-  secretAccessKey: process.env.s3_IAM_USER_SECRET
+  secretAccessKey: process.env.S3_IAM_USER_SECRET
 });
 
 const fileFilter = (request, file, cb) => {

--- a/endpoints/middleware/image-upload.js
+++ b/endpoints/middleware/image-upload.js
@@ -3,14 +3,17 @@ const uuid = require("uuid");
 const multer = require("multer");
 const multers3 = require("multer-s3");
 
-const bucketName = `amplify-mydish-be-dev-174150-deployment`;
+const bucketName = process.env.S3_BUCKET_NAME;
 
-var credentials = new aws.SharedIniFileCredentials({
-  profile: "mydishaws"
+// var credentials = new aws.SharedIniFileCredentials({
+//   profile: "mydishaws"
+// });
+// aws.config.credentials = credentials;
+
+const s3 = new aws.S3({
+  accesKeyId: process.env.S3_IAM_USER_KEY,
+  secretAccessKey: process.env.S3_IAM_USER_SECRET
 });
-aws.config.credentials = credentials;
-
-const s3 = new aws.S3();
 
 const fileFilter = (request, file, cb) => {
   console.log("fileFilter executing");


### PR DESCRIPTION
Changes BE to use ENV-provided AWS credentials and bucket designation as opposed to locally-stored INI-based auth.

Redoing PR to avoid Git shenanigans.