### PR TITLE
Updating recipe tags

### DIFF
--- a/__tests__/routers/recipes.test.js
+++ b/__tests__/routers/recipes.test.js
@@ -57,7 +57,7 @@ describe('POST "/recipes"', () => {
     );
     const expected_recipe = {
       ...new_recipe,
-      id: 1,       // New id that's been added to our object
+      id: 1, // New id that's been added to our object
       owner_id: 1, // From our mocked middleware token()
       test: true
     };
@@ -315,7 +315,7 @@ describe('GET "/cookbook"', () => {
     recipes_model.get_by_course = jest.fn(() => []);
     const expected_response = [];
 
-    const response = await request(server).get("/cookbook?course=snacks");
+    const response = await request(server).get("/cookbook?course=snack");
 
     expect(response.status).toEqual(200);
     expect(response.body).toEqual(expected_response);

--- a/data/seeds/006-tags.js
+++ b/data/seeds/006-tags.js
@@ -1,11 +1,11 @@
 const seed_data = [
-  { name: 'Breakfast' }, // id: 1, 
-  { name: 'Brunch' }, // id: 2, 
-  { name: 'Lunch' }, // id: 3, 
-  { name: 'Dinner' }, // id: 4, 
-  { name: 'Snacks' }, // id: 5, 
-  { name: 'Dessert' }, // id: 6, 
-]
+  { name: "Breakfast" }, // id: 1,
+  { name: "Brunch" }, // id: 2,
+  { name: "Lunch" }, // id: 3,
+  { name: "Dinner" }, // id: 4,
+  { name: "Snack" }, // id: 5,
+  { name: "Dessert" } // id: 6,
+];
 exports.tags_data = seed_data;
 
-exports.seed = knex => knex('tags').insert(seed_data);
+exports.seed = knex => knex("tags").insert(seed_data);

--- a/endpoints/models/recipes.js
+++ b/endpoints/models/recipes.js
@@ -303,7 +303,17 @@ const update_one = async (recipe_id, updated_recipe) => {
 
       //==========================UPDATING RECIPE_TAGS=============================//
 
-      // Currently not implemented.
+      const tag_ids = await db("tags")
+        .whereIn("name", updated_recipe.tags)
+        .select("id");
+      const recipe_tags_to_be_updated = tag_ids.map(tag => ({
+        recipe_id: recipe_id,
+        tag_id: tag.id
+      }));
+      await trx("recipe_tags")
+        .delete("recipe_tags")
+        .where("recipe_id", recipe_id);
+      await trx("recipe_tags").insert(recipe_tags_to_be_updated);
 
       //=======================UPDATING RECIPE_INSTRUCTIONS===========================//
 


### PR DESCRIPTION
Recipe tags can now be updated. When sending tags in an updated recipe, they must come in as an array of strings, with the strings being the exact name of the course. e.g. "tags" : [ "Breakfast","Brunch"]