### PR TITLE
Updating recipe bugfix: Cook time/Prep time

### DIFF
--- a/endpoints/models/recipes.js
+++ b/endpoints/models/recipes.js
@@ -532,8 +532,8 @@ const update_one = async (recipe_id, updated_recipe) => {
         img: updated_recipe.img || undefined,
         forked_from: updated_recipe.forked_from || undefined,
         owner_id: updated_recipe.owner_id,
-        prep_time: updated_recipe.prep_time || undefined,
-        cook_time: updated_recipe.cook_time || undefined,
+        prep_time: updated_recipe.prep_time || 0,
+        cook_time: updated_recipe.cook_time || 0,
         description: updated_recipe.description || undefined,
         author_comment: updated_recipe.author_comment,
         updated_at: new Date().toISOString()


### PR DESCRIPTION
Previously, sending the backend "" when updating a recipe in the cook_time or prep_time fields caused the backend to not change the value. Now, when sending a "" it will change the time to a 0